### PR TITLE
fix: Trelloのリスト内カード数カウント用のCSSセレクタを修正 (#CIT-1244) 

### DIFF
--- a/trello.user.css
+++ b/trello.user.css
@@ -5,7 +5,7 @@
 @author       siiibo
 @homepageURL  https://github.com/siiibo/stylus-siiibo
 @updateURL    https://raw.githubusercontent.com/siiibo/stylus-siiibo/main/trello.user.css
-@version      1.0.7
+@version      1.0.8
 @license      Unlicensed
 ==/UserStyle== */
 


### PR DESCRIPTION
2025/06頃に行われたTrelloのUI改修で、カードとカードの間に「新規カード作成」用のdiv要素が追加されたことでカードカウント数が合わなくなった。

nth-childからnth-of-typeに擬似クラスを変えることで修正。

