### PR TITLE
feat: Trelloの新UIに合わせてカードを開いた際のサイズ調整用CSSを更新 (#CIT-1291)

### DIFF
--- a/trello.user.css
+++ b/trello.user.css
@@ -57,9 +57,17 @@
   }
 
   /* カードを開いたときのウィンドウのカラムの幅を設定 */
-  div[data-testid="card-back-name"] > div > div > div:last-child {
-    grid-template-columns: [main] 4fr [sidebar] minmax(0, 1fr);
-    column-gap: 4%;
+  .card-back-redesign main {
+    width: 50%;
+  }
+  .card-back-redesign aside {
+    width: 50%;
+  }
+  .card-back-redesign main div {
+    max-width: none !important;
+  }
+  div[data-testid="card-back-panel"] {
+    width: 100% !important;
   }
 
   /* Doneリスト */

--- a/trello.user.css
+++ b/trello.user.css
@@ -53,7 +53,7 @@
 
   /* カードを開いたときのウィンドウ幅を設定 */
   #layer-manager-card-back div[role="dialog"] {
-    width: 70vw; /* 例として70vwに設定 */
+    width: 90vw;
   }
 
   /* カードを開いたときのウィンドウのカラムの幅を設定 */


### PR DESCRIPTION
Trelloが新UIになり、これまで説明欄とアクティビティログが上下に並んでいたものが左右に並ぶようになった。

Siiiboではアクティビティログをメインで活用しているが、上記の変更に伴ってアクティビティログが見づらくなったので、幅を広げた。

また、今回のUI刷新に伴って古いStylusを有効にしていると説明欄の表示が画面サイズによっておかしくなる問題が報告されていたので、そちらも修正。